### PR TITLE
Remove shell auto-import

### DIFF
--- a/xeus_python_shell/__init__.py
+++ b/xeus_python_shell/__init__.py
@@ -1,1 +1,0 @@
-from .shell import XPythonShell, XPythonShellApp  # noqa


### PR DESCRIPTION
This results in `from xeus_python_shell.lite_mocks import apply_mocks`
not importing the IPython shell automatically. This will help
xeus-python-raw into using the lite_mocks without needing IPython.