### PR TITLE
Set default Matplotlib backend to `inline`

### DIFF
--- a/xeus_python_shell/shell.py
+++ b/xeus_python_shell/shell.py
@@ -90,6 +90,10 @@ class XPythonShellApp(BaseIPythonApplication, InteractiveShellApp):
         self.init_path()
         self.init_shell()
 
+        if not os.environ.get("MPLBACKEND"):
+            os.environ["MPLBACKEND"] = "module://matplotlib_inline.backend_inline"
+        self.init_gui_pylab()
+
         self.init_extensions()
         self.init_code()
 

--- a/xeus_python_shell/shell.py
+++ b/xeus_python_shell/shell.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 # Emscripten platform needs multiple mocks to work
 if sys.platform == "emscripten":


### PR DESCRIPTION
Fixes jupyterlite/xeus-python-kernel#71